### PR TITLE
Adds draft Nifty dockerfiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # gemini_processing
+
+Nat's logbook: natnotes.md

--- a/natnotes.md
+++ b/natnotes.md
@@ -1,0 +1,94 @@
+# Nat's Logbook
+
+Just a space for me to keep notes on what I'm up to, how progress is happening, and so others can follow in my footsteps.
+
+## Questions
+
+- What are some attributes that your truly exceptional Co-op students have shown? Ie, what do you really like to see in students?
+
+## The Notes
+
+### Dockerizing Nifty
+
+In relation to #2. Goal is to get Nifty running in a Docker container.
+
+- Created an Ubuntu 20.04 VM, tried to get Nifty4Gemini 1.0.1 installed.
+	- Too slow?
+
+- Installed docker 19.03.8 on a mac
+	- Got the base anaconda image up and running. https://hub.docker.com/r/continuumio/anaconda/ . Ran ipython and conda.
+	- Got Nifty running in a docker image 
+		- https://hub.docker.com/r/michaelcs/astrocondairaf
+		- Built with "docker pull michaelcs/astrocondairaf"
+		- Launched (while mirroring a local directory so I could edit my login.cl): "docker run -i -t -v /Users/nat/new_iraf:/iraf michaelcs/astrocondairaf /bin/bash"
+		- Activated relevant conda environment with "source activate iraf27"
+		- Made a new "/iraf" directory and ran "mkiraf" within it
+		- Got nifty4gemini installed by downloading source and running "pip install -e ."
+		- Launched nifty with "runNifty nifsPipeline config.cfg" with the Titan config file, it started!!!
+	- Now working on getting the docker image automatically created
+		- This one creates a working interactive nifty4gemini container:
+			- Built it with "docker build --tag nifty:1.0 ."
+			- Launched it with "docker run -i -t -v /Volumes/NATGEMINI/docker/GN-2014A-Q-85:/scratch nifty:1.0 /bin/bash"
+			- Run a full reduction in it with "runNifty nifsPipeline -f GN-2014A-Q-85"
+
+```text
+FROM michaelcs/astrocondairaf
+
+ENV PATH /opt/conda/envs/iraf27/bin:$PATH
+RUN /bin/bash -c "source activate iraf27 && mkdir iraf && mkdir scratch && conda install pyqt=4"
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir nifty4gemini
+
+WORKDIR /iraf
+
+RUN /bin/bash -c "source activate iraf27 && mkiraf"
+
+RUN /bin/bash -c "echo 'source activate iraf27' > /root/.bashrc && echo 'if [ ! -f "/scratch/login.cl" ]; then ln -s /iraf/login.cl /scratch/login.cl; fi' >> /root/.bashrc"
+
+WORKDIR /scratch
+```
+
+	- Now working on getting on to be able to launch a reduction with "docker run -t nifty program_id" as per JJ's request
+		- Built with "docker build --tag auto_nifty:1.0 ."
+		- Ran with "docker run -t auto_nifty:1.0 <PROGRAM ID>"
+		- See the Dockerfile and "entrypoint.sh" script
+
+```text
+# Dockerfile
+
+FROM michaelcs/astrocondairaf
+
+ENV PATH /opt/conda/envs/iraf27/bin:$PATH
+RUN /bin/bash -c "source activate iraf27 && mkdir iraf && mkdir scratch && conda install pyqt=4"
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir nifty4gemini
+
+WORKDIR /iraf
+
+RUN /bin/bash -c "source activate iraf27 && mkiraf"
+
+WORKDIR /scratch
+
+# Create entrypoint script
+COPY entrypoint.sh /scratch
+RUN ["chmod", "+x", "/scratch/entrypoint.sh"]
+
+ENTRYPOINT [ "/scratch/entrypoint.sh" ]
+CMD [ "GN-2014A-Q-85" ]
+```
+
+```text
+#!/bin/bash
+
+ln -s /iraf/login.cl /scratch/login.cl
+
+source activate iraf27
+
+runNifty nifsPipeline -f $1
+```
+
+
+
+

--- a/nifs/dockerfiles/automatic_docker_container/Dockerfile
+++ b/nifs/dockerfiles/automatic_docker_container/Dockerfile
@@ -1,0 +1,20 @@
+FROM michaelcs/astrocondairaf
+
+ENV PATH /opt/conda/envs/iraf27/bin:$PATH
+RUN /bin/bash -c "source activate iraf27 && mkdir iraf && mkdir scratch && conda install pyqt=4"
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir nifty4gemini
+
+WORKDIR /iraf
+
+RUN /bin/bash -c "source activate iraf27 && mkiraf"
+
+WORKDIR /scratch
+
+# Create entrypoint script
+COPY entrypoint.sh /scratch
+RUN ["chmod", "+x", "/scratch/entrypoint.sh"]
+
+ENTRYPOINT [ "/scratch/entrypoint.sh" ]
+CMD [ "GN-2014A-Q-85" ]

--- a/nifs/dockerfiles/automatic_docker_container/entrypoint.sh
+++ b/nifs/dockerfiles/automatic_docker_container/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ln -s /iraf/login.cl /scratch/login.cl
+
+source activate iraf27
+
+runNifty nifsPipeline -f $1

--- a/nifs/dockerfiles/interactive_docker_container/Dockerfile
+++ b/nifs/dockerfiles/interactive_docker_container/Dockerfile
@@ -1,0 +1,15 @@
+FROM michaelcs/astrocondairaf
+
+ENV PATH /opt/conda/envs/iraf27/bin:$PATH
+RUN /bin/bash -c "source activate iraf27 && mkdir iraf && mkdir scratch && conda install pyqt=4"
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir nifty4gemini
+
+WORKDIR /iraf
+
+RUN /bin/bash -c "source activate iraf27 && mkiraf"
+
+RUN /bin/bash -c "echo 'source activate iraf27' > /root/.bashrc && echo 'if [ ! -f "/scratch/login.cl" ]; then ln -s /iraf/login.cl /scratch/login.cl; fi' >> /root/.bashrc"
+
+WORKDIR /scratch


### PR DESCRIPTION
This commit adds Dockerfiles for both an interative Nifty container and a
fully automatic Nifty container. For the interactive version, a build is
triggered with "docker build --tag nifty:1.0 ." and the container is run
interactively with
"docker run -i -t -v <host machine mount directory>:/scratch
nifty:1.0 /bin/bash", where a host machine mount directory is specified.
The fully automatic version was built with
"docker build --tag auto_nifty:1.0 ." and run with
"docker run -t auto_nifty:1.0 <PROGRAM ID>", where PROGRAM ID is a
Gemini program ID such as GN-2014A-Q-85. This (tentatively) solves #2 .